### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,9 +11,6 @@
 		"authors": ["hilburn"],
 		"credits": "Authored by hilburn, as an addon to VSWE's SFM",
 		"logoFile": "",
-		"screenshots": [],
-		"requiredMods": ["StevesFactoryManager", "CoFHCore"],
-		"dependencies": ["StevesFactoryManager", "CoFHCore"],
-		"useDependencyInformation": true
+		"screenshots": []
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.