### PR TITLE
Fix for copy button so it copies input&output nodes in command groups properly

### DIFF
--- a/src/main/java/stevesaddons/asm/StevesHooks.java
+++ b/src/main/java/stevesaddons/asm/StevesHooks.java
@@ -133,6 +133,7 @@ public class StevesHooks implements Hooks {
     private static void copyConnectionsWithChildren(Map<FlowComponent, FlowComponent> added,
             List<FlowComponent> existing, FlowComponent toCopy, FlowComponent newParent, boolean reset) {
         FlowComponent newComponent = toCopy.copy();
+        newComponent.setId(existing.size() + added.size());
         newComponent.clearConnections();
         newComponent.setParent(newParent);
         if (reset) {
@@ -140,7 +141,6 @@ public class StevesHooks implements Hooks {
             newComponent.setX(50);
             newComponent.setY(50);
         }
-        newComponent.setId(existing.size() + added.size());
         added.put(toCopy, newComponent);
         for (FlowComponent component : existing) {
             if (component.getParent() == toCopy) {


### PR DESCRIPTION
Made the ID for newComponent be set earlier before it's set as parent so that setParent won't sort in the wrong order, and thus improperly set input&output nodes in a command group.


here is a quick demonstration of the bug in the current build (It dosent map the output node correctly to the connection outside):

https://github.com/user-attachments/assets/31c567ef-8398-4953-966f-37d232ace06a

and here is a quick demonstration of how it works with the fix applied (it does map the output node correctly to the connection outside):

https://github.com/user-attachments/assets/b94865d5-ba57-4398-adae-72d824654e35

