### PR TITLE
Only send strings in LabelSyncMessage

### DIFF
--- a/src/main/java/stevesaddons/interfaces/GuiHandler.java
+++ b/src/main/java/stevesaddons/interfaces/GuiHandler.java
@@ -14,6 +14,6 @@ public class GuiHandler implements IGuiHandler {
 
     @Override
     public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-        return ID == 0 ? new GuiLabeler(player.getCurrentEquippedItem(), player) : null;
+        return ID == 0 ? new GuiLabeler(player.getCurrentEquippedItem()) : null;
     }
 }

--- a/src/main/java/stevesaddons/interfaces/GuiLabeler.java
+++ b/src/main/java/stevesaddons/interfaces/GuiLabeler.java
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -51,12 +50,11 @@ public class GuiLabeler extends GuiScreen implements IVerticalScrollContainer, I
     private ItemStack stack;
     private GuiTextField searchBar;
     private GuiVerticalScrollBar scrollBar;
-    private EntityPlayer player;
     public int mouseX = 0;
     public int mouseY = 0;
     private int xSize, ySize, guiLeft, guiTop;
 
-    public GuiLabeler(ItemStack stack, EntityPlayer player) {
+    public GuiLabeler(ItemStack stack) {
         this.stack = stack;
         for (String string : ItemLabeler.getSavedStrings(stack)) {
             strings.add(getGuiTextEntry(string));
@@ -68,7 +66,6 @@ public class GuiLabeler extends GuiScreen implements IVerticalScrollContainer, I
         searchBar.setText(ItemLabeler.getLabel(stack));
         searchBar.fixCursorPos();
         displayStrings = getSearchedStrings();
-        this.player = player;
     }
 
     public static GuiTextEntry getGuiTextEntry(String string) {
@@ -185,8 +182,9 @@ public class GuiLabeler extends GuiScreen implements IVerticalScrollContainer, I
         for (GuiTextEntry entry : strings) if (!save.contains(entry.getText())) save.add(entry.getText());
         searchBar.close();
         ItemLabeler.saveStrings(stack, save);
-        ItemLabeler.setLabel(stack, searchBar.getText());
-        MessageHandler.INSTANCE.sendToServer(new LabelSyncMessage(stack, player));
+        String searchText = searchBar.getText();
+        ItemLabeler.setLabel(stack, searchText);
+        MessageHandler.INSTANCE.sendToServer(new LabelSyncMessage(save, searchText));
     }
 
     @Override

--- a/src/main/java/stevesaddons/network/message/LabelSyncMessage.java
+++ b/src/main/java/stevesaddons/network/message/LabelSyncMessage.java
@@ -1,53 +1,60 @@
 package stevesaddons.network.message;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.world.WorldServer;
+import java.util.ArrayList;
+import java.util.List;
 
-import cpw.mods.fml.common.FMLCommonHandler;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import stevesaddons.items.ItemLabeler;
+import stevesaddons.registry.ItemRegistry;
 
 public class LabelSyncMessage implements IMessage, IMessageHandler<LabelSyncMessage, IMessage> {
 
-    ItemStack stack;
-    int id;
+    List<String> save;
+    String text;
 
     public LabelSyncMessage() {}
 
-    public LabelSyncMessage(ItemStack stack, EntityPlayer player) {
-        this.stack = stack;
-        this.id = player.getEntityId();
+    public LabelSyncMessage(List<String> save, String text) {
+        this.save = save;
+        this.text = text;
     }
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        this.stack = ByteBufUtils.readItemStack(buf);
-        id = buf.readInt();
+        int size = buf.readShort();
+        save = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            save.add(ByteBufUtils.readUTF8String(buf));
+        }
+        text = ByteBufUtils.readUTF8String(buf);
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
-        ByteBufUtils.writeItemStack(buf, stack);
-        buf.writeInt(id);
+        buf.writeShort(save.size());
+        for (String s : save) {
+            ByteBufUtils.writeUTF8String(buf, s);
+        }
+        ByteBufUtils.writeUTF8String(buf, text);
     }
 
     @Override
     public IMessage onMessage(LabelSyncMessage message, MessageContext ctx) {
-        EntityPlayer player = null;
-        for (WorldServer world : FMLCommonHandler.instance().getMinecraftServerInstance().worldServers) {
-            Entity entity = world.getEntityByID(message.id);
-            if (entity instanceof EntityPlayer) {
-                player = (EntityPlayer) entity;
-                break;
-            }
-        }
+        EntityPlayerMP player = ctx.getServerHandler().playerEntity;
         if (player != null) {
-            player.inventory.setInventorySlotContents(player.inventory.currentItem, message.stack);
+            ItemStack current = player.inventory.getCurrentItem();
+            if (current != null && current.getItem() == ItemRegistry.labeler) {
+                ItemLabeler.saveStrings(current, message.save);
+                ItemLabeler.setLabel(current, message.text);
+                player.inventory.setInventorySlotContents(player.inventory.currentItem, current);
+            }
         }
         return null;
     }


### PR DESCRIPTION
Let the server apply the strings and label rather than telling it what ItemStack to set. Also, remove the player field because its always the person sending the packet.